### PR TITLE
Bump frontrow-app

### DIFF
--- a/lts/17/15.yaml
+++ b/lts/17/15.yaml
@@ -23,7 +23,7 @@ packages:
 
   # https://app.asana.com/0/1160405925455011/1200183896199567/f
   - git: https://github.com/freckle/frontrow-app
-    commit: bcca27d863c95b7106afd4ea19b3a83fb93d5340
+    commit: 0a283e6f5fbbe21d9f63438432137f38cce65a5d
 
   # https://app.asana.com/0/399653121150251/1199556619843537/f
   - git: https://github.com/freckle/yesod-routes-flow

--- a/lts/18/0.yaml
+++ b/lts/18/0.yaml
@@ -15,7 +15,7 @@ packages:
 
   # https://app.asana.com/0/1160405925455011/1200183896199567/f
   - git: https://github.com/freckle/frontrow-app
-    commit: 04d1535295440735f507e6e563904cb67e4f04dd
+    commit: 0a283e6f5fbbe21d9f63438432137f38cce65a5d
 
   # https://app.asana.com/0/399653121150251/1199556619843537/f
   - git: https://github.com/freckle/yesod-routes-flow


### PR DESCRIPTION
Is this the right thing to do to bump the version of `frontrow-app`? The issue is that I guess we aren't on lts 18 for `megarepo` but my change for `frontrow-app` is on top of yours that bumps it to 18