### PR TITLE
Update 18.18 snapshot to specify dependencies for `weeder`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - lts/18/15.yaml
           - lts/18/16.yaml
           - lts/18/18.yaml
+          - lts/18/18/FR1.yaml
         include:
           - snapshot: lts/17/15.yaml
             extra-dependencies: '[frontrow-app]'
@@ -46,6 +47,8 @@ jobs:
           - snapshot: lts/18/16.yaml
             extra-dependencies: '[freckle-app]'
           - snapshot: lts/18/18.yaml
+            extra-dependencies: '[freckle-app]'
+          - snapshot: lts/18/18/FR1.yaml
             extra-dependencies: '[freckle-app]'
       fail-fast: false
 

--- a/lts/18/18/FR1.yaml
+++ b/lts/18/18/FR1.yaml
@@ -1,0 +1,55 @@
+# https://renaissancelearning.atlassian.net/wiki/spaces/EN/pages/41987178508/Shared+Backend+Stackage+Snapshot
+resolver: lts-18.18
+
+packages:
+  # === Dependencies we own
+
+  # Newer versions that will arrive in next major LTS
+  - faktory-1.1.2.1@sha256:cd63b696b273fa136d08d4b020a6859ceb7375a34b61129c470b827ab8ea0306,9080
+  - aws-xray-client-persistent-0.1.0.2@sha256:f00b3c3da576c488f2605ab5d049437d935eae429e7fe0eb9a6dc53d0367aebc,1682
+  - freckle-app-1.0.2.1@sha256:f8f80463b17ef9e08557fa4f414a19b797ffceca819c34eaae76d2b6fe4e2c47,6449
+
+  # https://github.com/freckle/asana/issues/29
+  - git: https://github.com/freckle/asana
+    commit: 91ce6ade118674bb273966943370684eba71f227
+
+  # https://app.asana.com/0/399653121150251/1199556619843537/f
+  - git: https://github.com/freckle/yesod-routes-flow
+    commit: 2a9cd873880956dd9a0999b593022d3c746324e8
+
+  # === Dependencies we don't own
+
+  # Newer versions that will arrive in next major LTS
+  - hspec-2.9.2@sha256:03c074bcadf13bdb5fda795fcce9f83a9532685d084bb0a325fdd632c3655a76,1709
+  - hspec-core-2.9.2@sha256:5ceab250e27469d775154d4d331e41e5805b0aa18567f4792ecbf8de2ce33c63,5563
+  - hspec-discover-2.9.2@sha256:19d259b90dfaf71449fede71a0e850cf16b57493d74624ffddf8cd67bcec8032,2167
+  - hspec-junit-formatter-1.0.3.0@sha256:644bb22cc8a53d1666a44bf6ce29885bd7008b10f32747b3a795b79fa80c6098,3914
+  - network-3.1.2.5@sha256:433a5e076aaa8eb3e4158abae78fb409c6bd754e9af99bc2e87583d2bcd8404a,4888
+
+  # Open an Issue asking the authors if they'd add them to Stackage and/or offer
+  # to adopt them in Stackage ourselves. Check in each LTS bump if they've been
+  # added yet.
+  - compact-0.2.0.0@sha256:9c5785bdc178ea6cf8f514ad35a78c64220e3cdb22216534e4cf496765551c7e,2345
+  - executable-hash-0.2.0.4@sha256:70d606ec3ab3a833af698f961439ae8ecb2b1238565e8af13d21d464d1838428,2435
+  - file-location-0.4.9.1@sha256:fb61c964f3aefbc32d2c2bac77a4a260d43d879959a62c56c2e3607aa79b9cad,2828
+  - monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
+  - monoidal-containers-0.6.0.1@sha256:7d776942659eb4d70d8b8da5d734396374a6eda8b4622df9e61e26b24e9c8e40,2501
+  - oidc-client-0.6.0.0@sha256:2079dc5c9dfb5b3e2fa93098254ca16787c01a0cd3634b1d84afe84c9a6c4825,3368
+  - pwstore-fast-2.4.4@sha256:9b6a37510d8b9f37f409a8ab3babac9181afcaaa3fce8ba1c131a7ed3de30698,1351
+
+  # For brittany-0.13.1.2
+  - data-tree-print-0.1.0.2@sha256:d845e99f322df70e0c06d6743bf80336f5918d5423498528beb0593a2afc1703,1620
+
+  # For stylish-haskell
+  - optparse-applicative-0.15.1.0@sha256:29ff6146aabf54d46c4c8788e8d1eadaea27c94f6d360c690c5f6c93dac4b07e,4810
+
+  # For weeder (which we're holding back to 2.2.0 because the latest targets GHC 9).
+  - dhall-1.40.2@sha256:db1d5f81912de498eeb8cf4535aebd76c695c016a8c5710970b61e83f3d345cb,34786
+  - generic-lens-2.2.0.0@sha256:4008a39f464e377130346e46062e2ac1211f9d2e256bbb1857216e889c7196be,3867
+
+  # 1.6.1 + fixes needed for newer unliftio, until 2.0 drops.
+  # https://github.com/brendanhay/amazonka/pull/617#issuecomment-830606997
+  - git: https://github.com/brendanhay/amazonka
+    commit: 14bc3248c423f486ae710d523b8996ddb3dac854
+    subdirs:
+      - amazonka


### PR DESCRIPTION
I broke our CI installation of weeder with #19:
```
Error: While constructing the build
plan, the following exceptions were
encountered:

In the dependencies for weeder-2.2.0:
    dhall-1.39.0 from stack
                 configuration does not
                 match ^>=1.30.0 || ^>=1.31.0 || ^>=1.32.0 || ^>=1.33.0 || ^>=1.34.0 || ^>=1.35.0 || ^>=1.36.0 || ^>=1.37.0 || ^>=1.40.0 
                 (latest matching
                 version is 1.40.2)
    generic-lens-2.1.0.0 from stack
                         configuration
                         does not
                         match ^>=1.1.0.0 || ^>=1.2.0.0 || ^>=2.0.0.0 || ^>=2.2.0.0 
                         (latest
                         matching
                         version
                         is 2.2.0.0)
needed since weeder is a build target.

Some different approaches to resolving
this:

  * Set 'allow-newer: true'
    in /root/.stack/config.yaml to ignore all version constraints and build anyway.

  * Recommended action: try adding the
    following to your extra-deps
    in /root/megarepo/backend/stack.yaml:

- dhall-1.40.2@sha256:db1d5f81912de498eeb8cf4535aebd76c695c016a8c5710970b61e83f3d345cb,34786
- generic-lens-2.2.0.0@sha256:4008a39f464e377130346e46062e2ac1211f9d2e256bbb1857216e889c7196be,3867

Plan construction failed.
```

This adds the exact dependencies, which successfully resolves the dependency plan (in local testing).