### PR TITLE
Add linting, bump hspec packages as lts-18.18-FR2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,45 @@ jobs:
           stack --no-terminal setup
           stack --no-terminal build --dependencies-only
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: prep
+        run: |
+          latest=$(find lts/ -type f | sort --reverse --version-sort | head -n 1)
+
+          if [ ! -f "$latest" ]; then
+            echo "Unable to find latest snapshot" >&2
+            exit 1
+          fi
+
+          echo "::set-output name=snapshot::$latest"
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            /tmp/cache/lsd
+          key: ${{ runner.os }}-${{ steps.prep.outputs.snapshot }}-lint
+
+      - uses: robinraju/release-downloader@v1.2
+        with:
+          repository: freckle/lsd
+          latest: true
+          fileName: lsd-x86_64-linux.tar.gz
+
+      - name: Extract
+        run: tar -xzf lsd-x86_64-linux.tar.gz
+
+      - name: Lint ${{ steps.prep.outputs.snapshot }}
+        run: |
+          ./lsd/lsd \
+            --cache-dir /tmp/cache/lsd \
+            --color always \
+            --exclude '*/amazonka' \
+            --exclude '*/yesod-routes-flow' \
+            ${{ steps.prep.outputs.snapshot }}
+
   status:
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
-on:
-  pull_request:
-  push:
-    branches: main
+on: pull_request
 
 jobs:
   test:
@@ -13,68 +10,40 @@ jobs:
       run:
         working-directory: test
 
-    strategy:
-      matrix:
-        snapshot:
-          - lts/17/15.yaml
-          - lts/18/0.yaml
-          - lts/18/2.yaml
-          - lts/18/5.yaml
-          - lts/18/10.yaml
-          - lts/18/13.yaml
-          - lts/18/13/FR1.yaml
-          - lts/18/15.yaml
-          - lts/18/16.yaml
-          - lts/18/18.yaml
-          - lts/18/18/FR1.yaml
-        include:
-          - snapshot: lts/17/15.yaml
-            extra-dependencies: '[frontrow-app]'
-          - snapshot: lts/18/0.yaml
-            extra-dependencies: '[frontrow-app]'
-          - snapshot: lts/18/2.yaml
-            extra-dependencies: '[frontrow-app]'
-          - snapshot: lts/18/5.yaml
-            extra-dependencies: '[freckle-app]'
-          - snapshot: lts/18/10.yaml
-            extra-dependencies: '[freckle-app]'
-          - snapshot: lts/18/13.yaml
-            extra-dependencies: '[freckle-app]'
-          - snapshot: lts/18/13/FR1.yaml
-            extra-dependencies: '[freckle-app]'
-          - snapshot: lts/18/15.yaml
-            extra-dependencies: '[freckle-app]'
-          - snapshot: lts/18/16.yaml
-            extra-dependencies: '[freckle-app]'
-          - snapshot: lts/18/18.yaml
-            extra-dependencies: '[freckle-app]'
-          - snapshot: lts/18/18/FR1.yaml
-            extra-dependencies: '[freckle-app]'
-      fail-fast: false
-
     steps:
       - uses: actions/checkout@v2
+      - id: prep
+        run: |
+          printf "::set-output name=snapshot::"
+          find ../lts/ -type f | sort --reverse --version-sort | head -n 1
+
       - name: Setup
         run: |
-          m4 -D RESOLVER=../${{ matrix.snapshot }} \
+          m4 -D RESOLVER=${{ steps.prep.outputs.snapshot }} \
             < stack.yaml.in > stack.yaml
-          m4 -D EXTRA_DEPENDENCIES=${{ matrix.extra-dependencies }} \
-            < package.yaml.in > package.yaml
 
       - uses: actions/cache@v2
         with:
           path: |
             ~/.stack
             ./test/.stack-work
-          key: ${{ matrix.snapshot }}-${{ hashFiles('test/*.yaml') }}
+          key: ${{ steps.prep.outputs.snapshot }}-${{ hashFiles('test/*.yaml') }}
           restore-keys: |
-            ${{ matrix.snapshot }}-
+            ${{ steps.prep.outputs.snapshot }}-
 
       - name: Build
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           stack --no-terminal setup
           stack --no-terminal build --dependencies-only
+          stack --no-terminal install --copy-compiler-tool \
+            apply-refact \
+            dhall \
+            fast-tags \
+            hlint \
+            stylish-haskell \
+            brittany-0.13.1.2 \
+            weeder-2.2.0
 
   lint:
     runs-on: ubuntu-latest
@@ -82,20 +51,8 @@ jobs:
       - uses: actions/checkout@v2
       - id: prep
         run: |
-          latest=$(find lts/ -type f | sort --reverse --version-sort | head -n 1)
-
-          if [ ! -f "$latest" ]; then
-            echo "Unable to find latest snapshot" >&2
-            exit 1
-          fi
-
-          echo "::set-output name=snapshot::$latest"
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            /tmp/cache/lsd
-          key: ${{ runner.os }}-${{ steps.prep.outputs.snapshot }}-lint
+          printf "::set-output name=snapshot::"
+          find lts/ -type f | sort --reverse --version-sort | head -n 1
 
       - uses: robinraju/release-downloader@v1.2
         with:
@@ -109,14 +66,7 @@ jobs:
       - name: Lint ${{ steps.prep.outputs.snapshot }}
         run: |
           ./lsd/lsd \
-            --cache-dir /tmp/cache/lsd \
             --color always \
             --exclude '*/amazonka' \
             --exclude '*/yesod-routes-flow' \
             ${{ steps.prep.outputs.snapshot }}
-
-  status:
-    needs: [test]
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Job to act as our overall required PR Status"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ We define Snapshots built on a given LTS and match the same file structure:
 lts-X.Y -> lts/X/Y.yaml
 ```
 
+Once committed to `main`, **Snaphots are immutable**. These files are cached in
+various ways as they're used and modifying one in place could result in a very
+confusing and frustrating experience for developers.
+
 To make updates to a Snapshot without changing the base resolver, create a new
 snapshot at:
 
@@ -39,29 +43,32 @@ We try to do this every two weeks, but feel free to do it whenever you like.
 
 1. Run `bin/new-snapshot`
 
-Proceed with the following maintenance steps:
+## Automated linting
 
-### Update any dependencies
+CI will run [LSD][], which checks for:
 
-**Do any git dependencies have the changes we need in Hackage now?**
+[lsd]: https://github.com/freckle/lsd
 
-If so, make them Hackage dependencies. If not,
+- Any Hackage dependencies with same-or-newer version in Stackage
 
-**Do any git dependencies have newer commits?**
+  We should remove the `extra-dep`, unless there's a reason we're staying behind.
 
-If so, and they're our own package, update the `commit` to latest. If they are
-not our own package, leave them be. Unless there is explicit reason to update,
-we'll wait until the next Hackage version for packages we don't own ourselves.
+- Any Hackage dependencies with a newer released version
 
-**Do any Hackage dependences have this version (or newer) in the new resolver?**
+  We should update, unless there's a reason we're staying behind.
 
-If so, remove them and rely on the resolver version. If not,
+- Any Git dependencies with a version-like tag newer than the commit
 
-**Do any Hackage dependencies have newer versions on Hackage?**
+  This likely means a released version on Hackage we can move to.
 
-If so, update to them.
+- Any Git dependencies with newer commits on the default branch
 
-### Updating Hackage package checksums
+  We may want to update.
+
+If the `lint` step generates a false-positive, you can silence it by adding an
+`--exclude` option.
+
+## Updating Hackage package checksums
 
 - Update the version, and throw the previous SHA off in some minor way
 
@@ -94,12 +101,12 @@ If so, update to them.
   +  - freckle-app-1.0.0.4@sha256:8cb624bb3e8805d626b700127690d54d1ddc736073720ac9806a3b04dd3c3216,6244
   ```
 
-### Testing the snapshot
+## Testing the snapshot
 
 `bin/check` performs a `--dry-run` build, which is fast but not a real guarantee
 that the snapshot will compile. CI builds the representative package fully.
 
-### Migrate each Application to the new snapshots
+## Migrating Applications
 
 Remove any app-specific `extra-deps` are no longer required.
 

--- a/bin/new-snapshot
+++ b/bin/new-snapshot
@@ -26,5 +26,4 @@ if [[ "$latest_resolver" != "$current_resolver" ]]; then
   mkdir -p "$(dirname "$latest_snapshot")"
   sed 's/^\(resolver: *\)[^ ]*\(.*\)$/\1'"$latest_resolver"'\2/' "$current_snapshot" >"$latest_snapshot"
   echo "Created $latest_snapshot ($latest_resolver) snapshot from $current_snapshot"
-  echo "Don't forget to update .github/workflows/ci.yml to include it"
 fi

--- a/lts/18/18/FR2.yaml
+++ b/lts/18/18/FR2.yaml
@@ -1,0 +1,55 @@
+# https://renaissancelearning.atlassian.net/wiki/spaces/EN/pages/41987178508/Shared+Backend+Stackage+Snapshot
+resolver: lts-18.18
+
+packages:
+  # === Dependencies we own
+
+  # Newer versions that will arrive in next major LTS
+  - faktory-1.1.2.1@sha256:cd63b696b273fa136d08d4b020a6859ceb7375a34b61129c470b827ab8ea0306,9080
+  - aws-xray-client-persistent-0.1.0.2@sha256:f00b3c3da576c488f2605ab5d049437d935eae429e7fe0eb9a6dc53d0367aebc,1682
+  - freckle-app-1.0.2.2@sha256:93bf2fcac81e63f3dc9a75dc0c557d729f1ff7902dce9ab6da4b1852a80eac13,6445
+
+  # https://github.com/freckle/asana/issues/29
+  - git: https://github.com/freckle/asana
+    commit: 91ce6ade118674bb273966943370684eba71f227
+
+  # https://app.asana.com/0/399653121150251/1199556619843537/f
+  - git: https://github.com/freckle/yesod-routes-flow
+    commit: 2a9cd873880956dd9a0999b593022d3c746324e8
+
+  # === Dependencies we don't own
+
+  # Newer versions that will arrive in next major LTS
+  - hspec-2.9.4@sha256:658a6a74d5a70c040edd6df2a12228c6d9e63082adaad1ed4d0438ad082a0ef3,1709
+  - hspec-core-2.9.4@sha256:a126e9087409fef8dcafcd2f8656456527ac7bb163ed4d9cb3a57589042a5fe8,6498
+  - hspec-discover-2.9.4@sha256:fbcf49ecfc3d4da53e797fd0275264cba776ffa324ee223e2a3f4ec2d2c9c4a6,2165
+  - hspec-junit-formatter-1.1.0.0@sha256:c2f453440fc526cfd8f880b67876ac64d6e0fa13c8e94722a86e7996882e8ed0,3825
+  - network-3.1.2.5@sha256:433a5e076aaa8eb3e4158abae78fb409c6bd754e9af99bc2e87583d2bcd8404a,4888
+
+  # Open an Issue asking the authors if they'd add them to Stackage and/or offer
+  # to adopt them in Stackage ourselves. Check in each LTS bump if they've been
+  # added yet.
+  - compact-0.2.0.0@sha256:9c5785bdc178ea6cf8f514ad35a78c64220e3cdb22216534e4cf496765551c7e,2345
+  - executable-hash-0.2.0.4@sha256:70d606ec3ab3a833af698f961439ae8ecb2b1238565e8af13d21d464d1838428,2435
+  - file-location-0.4.9.1@sha256:fb61c964f3aefbc32d2c2bac77a4a260d43d879959a62c56c2e3607aa79b9cad,2828
+  - monad-validate-1.2.0.0@sha256:9850f408431098b28806dd464b6825a88a0b56c84f380d7fe0454c1df9d6f881,3505
+  - monoidal-containers-0.6.0.1@sha256:7d776942659eb4d70d8b8da5d734396374a6eda8b4622df9e61e26b24e9c8e40,2501
+  - oidc-client-0.6.0.0@sha256:2079dc5c9dfb5b3e2fa93098254ca16787c01a0cd3634b1d84afe84c9a6c4825,3368
+  - pwstore-fast-2.4.4@sha256:9b6a37510d8b9f37f409a8ab3babac9181afcaaa3fce8ba1c131a7ed3de30698,1351
+
+  # For brittany-0.13.1.2
+  - data-tree-print-0.1.0.2@sha256:d845e99f322df70e0c06d6743bf80336f5918d5423498528beb0593a2afc1703,1620
+
+  # For stylish-haskell
+  - optparse-applicative-0.15.1.0@sha256:29ff6146aabf54d46c4c8788e8d1eadaea27c94f6d360c690c5f6c93dac4b07e,4810
+
+  # For weeder (which we're holding back to 2.2.0 because the latest targets GHC 9).
+  - dhall-1.40.2@sha256:db1d5f81912de498eeb8cf4535aebd76c695c016a8c5710970b61e83f3d345cb,34786
+  - generic-lens-2.2.0.0@sha256:4008a39f464e377130346e46062e2ac1211f9d2e256bbb1857216e889c7196be,3867
+
+  # 1.6.1 + fixes needed for newer unliftio, until 2.0 drops.
+  # https://github.com/brendanhay/amazonka/pull/617#issuecomment-830606997
+  - git: https://github.com/brendanhay/amazonka
+    commit: 14bc3248c423f486ae710d523b8996ddb3dac854
+    subdirs:
+      - amazonka

--- a/test/package.yaml
+++ b/test/package.yaml
@@ -1,8 +1,6 @@
 name: example
 version: 0.0.0.0
 
-# Library dependencies should be packages that are available to check within
-# any of our snapshots.
 library:
   dependencies:
     - Glob
@@ -75,6 +73,7 @@ library:
     - filepath
     - foldl
     - formatting
+    - freckle-app
     - gauge
     - generic-arbitrary
     - graphula
@@ -185,9 +184,3 @@ library:
     - yesod-routes-flow
     - yesod-static
     - yesod-test
-
-executables:
-  # This executable's dependencies are injected on a snapshot-by-snapshot basis to
-  # extend the test packages for that snapshot only.
-  example:
-    dependencies: EXTRA_DEPENDENCIES


### PR DESCRIPTION
Adds [LSD](https://github.com/freckle/lsd)

Creates lts/18/18/FR2

- Update hspec packages from 2.9.2 to 2.9.4
- Update hspec-junit-formatter, fix but on case-insensitive filesystems
- Update freckle-app for newer hspec-hunit-formatter