### PR TITLE
Add scheduled workflow for new resolvers

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,25 @@
+name: Bump
+
+on:
+  schedule:
+    - cron: "0 0 01 * *"
+    - cron: "0 0 14 * *"
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: bump
+        run: ./bin/new-snapshot
+
+      - if: ${{ steps.bump.outputs.bumped == 'true' }}
+        uses: peter-evans/create-pull-request@v3
+        with:
+          add-paths: ${{ steps.bump.outputs.path }}
+          commit-message: 'Create ${{ steps.bump.outputs.to }} Snapshot'
+          title: 'Create ${{ steps.bump.outputs.to }} Snapshot'
+          body: '[Resolver Changelog](https://rcl.freckle.com/?from=${{ steps.bump.outputs.from }}&to=${{ steps.bump.outputs.to }}).'
+          team-reviewers: freckle/backenders

--- a/bin/new-snapshot
+++ b/bin/new-snapshot
@@ -26,4 +26,11 @@ if [[ "$latest_resolver" != "$current_resolver" ]]; then
   mkdir -p "$(dirname "$latest_snapshot")"
   sed 's/^\(resolver: *\)[^ ]*\(.*\)$/\1'"$latest_resolver"'\2/' "$current_snapshot" >"$latest_snapshot"
   echo "Created $latest_snapshot ($latest_resolver) snapshot from $current_snapshot"
+
+  if [[ ${GITHUB_ACTIONS:-false} == 'true' ]]; then
+    printf '::set-output name=bumped::true\n'
+    printf '::set-output name=from::%s\n' "$current_resolver"
+    printf '::set-output name=to::%s\n' "$latest_resolver"
+    printf '::set-output name=path::%s\n' "$latest_snapshot"
+  fi
 fi


### PR DESCRIPTION
Each month on the 1st and 14th (i.e. roughly every 2 weeks), run the
new-snapshot script. If it indeed generates a new snapshot, open a Pull
Request for review.
