### PR TITLE
Add hspec-junit-formatter 1.1.0.1 resolver

### DIFF
--- a/lts/19/1/FR1.yaml
+++ b/lts/19/1/FR1.yaml
@@ -1,0 +1,62 @@
+# https://renaissancelearning.atlassian.net/wiki/spaces/EN/pages/41987178508/Shared+Backend+Stackage+Snapshot
+resolver: lts-19.1
+
+packages:
+  # === Dependencies we own
+  - aws-xray-client-0.1.0.2
+  - aws-xray-client-persistent-0.1.0.5
+  - aws-xray-client-wai-0.1.0.2
+  - bcp47-0.2.0.6
+  - bcp47-orphans-0.1.0.5
+  - freckle-app-1.0.2.10
+  - sendgrid-v3-0.3.0.0
+
+  # Newer versions that will arrive in next major LTS
+  - hspec-junit-formatter-1.1.0.1@sha256:0365b3a5aa2e292604826c7cf99ace8b3248a369d8f5821edff9bc1031e16a5c,3853
+
+  # https://github.com/freckle/asana/issues/29
+  - github: freckle/asana
+    commit: 9908eec940a6e4e19f5dd0ce1ebada2771f99f55
+
+  # === Dependencies we don't own
+  - country-0.2.2
+  - datadog-0.3.0.0
+  - ekg-core-0.1.1.7
+  - file-location-0.4.9.1
+  - jose-jwt-0.9.4
+  - oauthenticated-0.3.0.0
+  - oidc-client-0.6.0.0
+  - pwstore-fast-2.4.4
+
+  # Transitive dependencies for country
+  - run-st-0.1.1.0
+  - zigzag-0.0.1.0
+  - bytebuild-0.3.10.0
+  - bytehash-0.1.0.0
+  - byteslice-0.2.7.0
+  - contiguous-0.6.1.1
+
+  # For weeder-2.3.0
+  - algebraic-graphs-0.5
+
+  # https://github.com/hasura/monad-validate/pull/5
+  - github: LeapYear/monad-validate
+    commit: 5b181b7c57d6e2c975c533b0a0072e9aeb15fb99
+
+  # 2.0-rc + SSO support
+  - github: brendanhay/amazonka
+    commit: f73a957d05f64863e867cf39d0db260718f0fadd
+    subdirs:
+      - lib/amazonka
+      - lib/amazonka-core
+      - lib/services/amazonka-cloudformation
+      - lib/services/amazonka-cloudwatch-logs
+      - lib/services/amazonka-ecr
+      - lib/services/amazonka-ecs
+      - lib/services/amazonka-polly
+      - lib/services/amazonka-rds
+      - lib/services/amazonka-s3
+      - lib/services/amazonka-sns
+      - lib/services/amazonka-ssm
+      - lib/services/amazonka-sso
+      - lib/services/amazonka-sts


### PR DESCRIPTION
When using the new `/lts/19/1.yaml` the following warning happens for `freckle-app`

```
WARNING: Ignoring freckle-app's bounds on hspec-junit-formatter (>=1.1.0.1); using hspec-junit-formatter-1.0.3.0.
Reason: trusting snapshot over cabal file dependency information.
```

We had a case-insensitivity macOS bug for that particular version, so anything depending on this snapshot fails when building on a mac. 

This adds the v1.1.0.1 of the library to a new `/lts/19/1/FR1.yaml` snapshot.  This does produce a new set of warnings  when running `./bin/check lts/19/1/FR1.yaml `, but I am not sure if this is a problem? I'll build `fancy-api` against this snapshot to ensure that it's working as intended.

```
WARNING: Ignoring ekg-core's bounds on base (>=4.6 && <4.15); using base-4.15.1.0.
Reason: trusting snapshot over cabal file dependency information.
WARNING: Ignoring ekg-core's bounds on ghc-prim (<0.7); using ghc-prim-0.7.0.
Reason: trusting snapshot over cabal file dependency information.
WARNING: Ignoring sendgrid-v3's bounds on base (>=4.8 && <4.15); using base-4.15.1.0.
Reason: trusting snapshot over cabal file dependency information.
```