### PR TITLE
Create lts-20.6 Snapshot

### DIFF
--- a/lts/20/6.yaml
+++ b/lts/20/6.yaml
@@ -1,0 +1,32 @@
+# https://renaissancelearning.atlassian.net/wiki/spaces/EN/pages/41987178508/Shared+Backend+Stackage+Snapshot
+resolver: lts-20.6
+
+packages:
+  # === Dependencies we own
+  - asana-1.0.0.0
+  - freckle-app-1.7.1.0
+
+  # === Dependencies we don't own
+  - file-location-0.4.9.1
+  - monad-validate-1.2.0.1
+
+  # Megarepo needs updates to use latest (0.7)
+  - oidc-client-0.6.1.0
+
+  # 2.0-rc + SSO support
+  - github: brendanhay/amazonka
+    commit: f73a957d05f64863e867cf39d0db260718f0fadd
+    subdirs:
+      - lib/amazonka
+      - lib/amazonka-core
+      - lib/services/amazonka-cloudformation
+      - lib/services/amazonka-cloudwatch-logs
+      - lib/services/amazonka-ecr
+      - lib/services/amazonka-ecs
+      - lib/services/amazonka-polly
+      - lib/services/amazonka-rds
+      - lib/services/amazonka-s3
+      - lib/services/amazonka-sns
+      - lib/services/amazonka-ssm
+      - lib/services/amazonka-sso
+      - lib/services/amazonka-sts

--- a/lts/20/6.yaml
+++ b/lts/20/6.yaml
@@ -4,7 +4,7 @@ resolver: lts-20.6
 packages:
   # === Dependencies we own
   - asana-1.0.0.0
-  - freckle-app-1.7.1.0
+  - freckle-app-1.8.1.0
 
   # === Dependencies we don't own
   - file-location-0.4.9.1


### PR DESCRIPTION
This PR was created automatically because a new LTS was available.
See [here][readme] for more details.

For a list of changed packages, see [here][rcl].

[readme]: https://github.com/freckle/stackage-snapshots#creating-a-new-snapshot
[rcl]: https://rcl.freckle.com/?from=lts-20.2&to=lts-20.6